### PR TITLE
Store User object in auth context and fix tests

### DIFF
--- a/planner-api/openapi.yaml
+++ b/planner-api/openapi.yaml
@@ -85,7 +85,7 @@ components:
         accessToken:
           type: "string"
           format: "encoded access token"
-          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMSIsImV4cCI6MjE0NzQ4MzY0N30.L-OzhC0g5TVQr0tcg75S1pGn57vr1MjumtHT_atU3Ag"
+          example: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMiIsImV4cCI6MTY0OTk2MTYzOCwidXNlcklkIjoxfQ.rWcKHXk8Q-QWchLEEBRlxSS3owbbQa5azSM4ag5ogpY"
 
     AccessToken:
       type: "object"
@@ -111,3 +111,7 @@ components:
               type: "integer"
               format: "int64"
               description: "Expiration (Unix epoch second)"
+            userId:
+              type: "integer"
+              format: "int32"
+              description: "Owner's ID"

--- a/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/Current.java
+++ b/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/Current.java
@@ -1,0 +1,13 @@
+package pl.edu.agh.kuce.planner.auth;
+
+import org.springframework.security.core.annotation.CurrentSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@CurrentSecurityContext(expression = "authentication.principal")
+public @interface Current {}

--- a/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/JwtAuthFilter.java
+++ b/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/JwtAuthFilter.java
@@ -35,14 +35,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         }
 
         String token = authHeader.replaceFirst(AUTH_HEADER_PREFIX, "");
-        var nick = jwtUtils.tryRetrieveNick(token);
-        if (nick.isEmpty()) {
+        var user = jwtUtils.verifyToken(token);
+        if (user.isEmpty()) {
             filterChain.doFilter(request, response);
             return;
         }
 
         SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(nick.get(), null, List.of())
+                new UsernamePasswordAuthenticationToken(user.get(), null, List.of())
         );
 
         filterChain.doFilter(request, response);

--- a/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/config/JwtConfig.java
+++ b/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/config/JwtConfig.java
@@ -1,11 +1,12 @@
 package pl.edu.agh.kuce.planner.auth.config;
 
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Clock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.time.Clock;
+import java.util.Date;
 
 @Configuration
 public class JwtConfig {
@@ -16,7 +17,7 @@ public class JwtConfig {
     }
 
     @Bean
-    public Clock clock() {
-        return Clock.systemUTC();
+    public Clock jwtClock() {
+        return Date::new;
     }
 }

--- a/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/service/AuthService.java
+++ b/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/service/AuthService.java
@@ -27,7 +27,7 @@ public class AuthService {
                 new User(request.nick(), request.email(), passwordEncoder.encode(request.password()))
         );
 
-        return new AuthResponseDto(jwtUtils.createAccessToken(user.getNick()));
+        return new AuthResponseDto(jwtUtils.createAccessToken(user));
     }
 
     public AuthResponseDto login(LoginRequestDto request) {
@@ -40,6 +40,6 @@ public class AuthService {
             throw new BadCredentialsException("Wrong password");
         }
 
-        return new AuthResponseDto(jwtUtils.createAccessToken(user.get().getNick()));
+        return new AuthResponseDto(jwtUtils.createAccessToken(user.get()));
     }
 }

--- a/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/service/JwtService.java
+++ b/planner-api/src/main/java/pl/edu/agh/kuce/planner/auth/service/JwtService.java
@@ -1,52 +1,67 @@
 package pl.edu.agh.kuce.planner.auth.service;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.JWTVerifier.BaseVerification;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Clock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import pl.edu.agh.kuce.planner.auth.persistence.User;
 
-import java.time.Clock;
 import java.util.Date;
 import java.util.Optional;
 
 @Service
 public class JwtService {
 
+    private static final String USER_ID_CLAIM = "userId";
+
+    private final JWTVerifier jwtVerifier;
     private final Algorithm algorithm;
     private final Clock clock;
     private final long accessTokenDurationMillis;
 
-    public JwtService(Algorithm algorithm, Clock clock,
+    public JwtService(Clock clock, Algorithm algorithm,
                       @Value("${jwt.access-token-duration-millis}") long accessTokenDurationMillis) {
+        jwtVerifier = ((BaseVerification) JWT.require(algorithm)).build(clock);
         this.algorithm = algorithm;
         this.clock = clock;
         this.accessTokenDurationMillis = accessTokenDurationMillis;
     }
 
-    public String createAccessToken(String nick) {
-        return createToken(nick, accessTokenDurationMillis);
+    public String createAccessToken(User user) {
+        return createToken(user, accessTokenDurationMillis);
     }
 
-    public Optional<String> tryRetrieveNick(String token) {
+    public Optional<User> verifyToken(String token) {
         try {
-            return Optional.ofNullable(JWT.require(algorithm)
-                    .build()
-                    .verify(token)
-                    .getSubject());
+            var decodedToken = jwtVerifier.verify(token);
+
+            var user = new User();
+            user.setId(decodedToken.getClaim(USER_ID_CLAIM).asInt());
+            user.setNick(decodedToken.getSubject());
+
+            if (user.getId() == null || user.getNick() == null) {
+                return Optional.empty();
+            }
+
+            return Optional.of(user);
         } catch (JWTVerificationException e) {
             return Optional.empty();
         }
     }
 
-    private String createToken(String nick, long duration) {
+    private String createToken(User user, long duration) {
         return JWT.create()
-                .withSubject(nick)
+                .withSubject(user.getNick())
+                .withClaim(USER_ID_CLAIM, user.getId())
                 .withExpiresAt(getDateFromNow(duration))
                 .sign(algorithm);
     }
 
     private Date getDateFromNow(long durationMillis) {
-        return new Date(clock.millis() + durationMillis);
+        return new Date(clock.getToday().getTime() + durationMillis);
     }
 }

--- a/planner-api/src/main/resources/application.properties
+++ b/planner-api/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.url=jdbc:postgresql://localhost:5432/planner
-spring.datasource.username=user
+spring.datasource.username=someUser
 spring.datasource.password=somePassword
 
 spring.jpa.hibernate.ddl-auto=update

--- a/planner-api/src/test/java/pl/edu/agh/kuce/planner/auth/integration/AuthTest.java
+++ b/planner-api/src/test/java/pl/edu/agh/kuce/planner/auth/integration/AuthTest.java
@@ -17,7 +17,7 @@ import pl.edu.agh.kuce.planner.auth.persistence.User;
 import pl.edu.agh.kuce.planner.auth.persistence.UserRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -46,17 +46,13 @@ class AuthTest {
 
     @Test
     @Transactional
-    void givenValidCredentials_register_returnsJwt() throws Exception {
+    void givenValidCredentials_register_returns200() throws Exception {
         var request = new RegistrationRequestDto("user", "email@example.com", "password");
-
-        String expectedJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." +
-                             "eyJzdWIiOiJ1c2VyIiwiZXhwIjoxNjQ4NzYwODAxfQ." +
-                             "jDa3CL4InUwyCu_bYHJ4-JfVs5g7t19h3iCjyT6fr1w";
 
         mockMvc.perform(post("/api/auth/users").contentType(MediaType.APPLICATION_JSON).content(toJson(request)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.accessToken", is(expectedJwt)));
+                .andExpect(jsonPath("$.accessToken", matchesPattern("^.+\\..+\\..+$")));
     }
 
     @Test
@@ -80,36 +76,28 @@ class AuthTest {
 
     @Test
     @Transactional
-    void givenValidNickPassword_login_returnsJwt() throws Exception {
+    void givenValidNickPassword_login_returns200() throws Exception {
         userRepository.save(fakeUser());
 
         var request = new LoginRequestDto("user", "password");
 
-        String expectedJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." +
-                "eyJzdWIiOiJ1c2VyIiwiZXhwIjoxNjQ4NzYwODAxfQ." +
-                "jDa3CL4InUwyCu_bYHJ4-JfVs5g7t19h3iCjyT6fr1w";
-
         mockMvc.perform(post("/api/auth/access-token").contentType(MediaType.APPLICATION_JSON).content(toJson(request)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.accessToken", is(expectedJwt)));
+                .andExpect(jsonPath("$.accessToken", matchesPattern("^.+\\..+\\..+$")));
     }
 
     @Test
     @Transactional
-    void givenValidEmailPassword_login_returnsJwt() throws Exception {
+    void givenValidEmailPassword_login_returns200() throws Exception {
         userRepository.save(fakeUser());
 
         var request = new LoginRequestDto("email@example.com", "password");
 
-        String expectedJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." +
-                "eyJzdWIiOiJ1c2VyIiwiZXhwIjoxNjQ4NzYwODAxfQ." +
-                "jDa3CL4InUwyCu_bYHJ4-JfVs5g7t19h3iCjyT6fr1w";
-
         mockMvc.perform(post("/api/auth/access-token").contentType(MediaType.APPLICATION_JSON).content(toJson(request)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.accessToken", is(expectedJwt)));
+                .andExpect(jsonPath("$.accessToken", matchesPattern("^.+\\..+\\..+$")));
     }
 
     @Test
@@ -154,8 +142,8 @@ class AuthTest {
     @Test
     void givenFakeSecuredApiEndpoint_requestWithJwt_returns404() throws Exception {
         String validToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." +
-                "eyJzdWIiOiJ1c2VyIiwiZXhwIjoyMTQ3NDgzNjQ3fQ." +
-                "ZDr5cWMLgEzxAS6kJ6nbMOP0B4R1iY1QeH0CpnWulag";
+                "eyJzdWIiOiJ1c2VyIiwidXNlcklkIjoxLCJleHAiOjIxNDc0ODM2NDd9." +
+                "d5lbk3hpiyvPS1gVsdGwrDzXz_r794CHDUU6sP1lkiU";
         String headerValue = "Bearer " + validToken;
 
         mockMvc.perform(get("/api/fake-endpoint/fake-path").header("Authorization", headerValue))

--- a/planner-api/src/test/java/pl/edu/agh/kuce/planner/auth/integration/AuthTestConfig.java
+++ b/planner-api/src/test/java/pl/edu/agh/kuce/planner/auth/integration/AuthTestConfig.java
@@ -1,12 +1,11 @@
 package pl.edu.agh.kuce.planner.auth.integration;
 
+import com.auth0.jwt.interfaces.Clock;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
+import java.util.Date;
 
 @TestConfiguration
 public class AuthTestConfig {
@@ -14,6 +13,6 @@ public class AuthTestConfig {
     @Bean
     @Primary
     public Clock fixedClock() {
-        return Clock.fixed(Instant.ofEpochSecond(1648760741), ZoneId.of("Europe/Warsaw")); //fixed 31.03.2022
+        return () -> new Date(1648760741000L); //fixed 31.03.2022
     }
 }

--- a/planner-api/src/test/java/pl/edu/agh/kuce/planner/auth/service/AuthServiceTest.java
+++ b/planner-api/src/test/java/pl/edu/agh/kuce/planner/auth/service/AuthServiceTest.java
@@ -42,15 +42,13 @@ class AuthServiceTest {
         MockitoAnnotations.openMocks(this);
 
         when(userRepository.save(any())).thenReturn(fakeUser);
-        when(userRepository.save(any())).thenReturn(fakeUser);
-        when(userRepository.save(any())).thenReturn(fakeUser);
         when(userRepository.findOneByNickOrEmail(fakeUser.getNick())).thenReturn(Optional.of(fakeUser));
         when(userRepository.findOneByNickOrEmail(fakeUser.getEmail())).thenReturn(Optional.of(fakeUser));
 
         when(passwordEncoder.encode("password1")).thenReturn(fakeUser.getPasswordHash());
         when(passwordEncoder.matches("password1", "hashedPassword1")).thenReturn(true);
 
-        when(jwtService.createAccessToken(fakeUser.getNick())).thenReturn("token1");
+        when(jwtService.createAccessToken(fakeUser)).thenReturn("token1");
 
         authService = new AuthService(userRepository, passwordEncoder, jwtService);
     }

--- a/planner-api/src/test/java/pl/edu/agh/kuce/planner/auth/service/JwtServiceTest.java
+++ b/planner-api/src/test/java/pl/edu/agh/kuce/planner/auth/service/JwtServiceTest.java
@@ -3,10 +3,9 @@ package pl.edu.agh.kuce.planner.auth.service;
 import com.auth0.jwt.algorithms.Algorithm;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import pl.edu.agh.kuce.planner.auth.persistence.User;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,53 +16,57 @@ class JwtServiceTest {
     @BeforeEach
     void setUp() {
         jwtService = new JwtService(
+                () -> new Date(1648760741000L), //fixed 31.03.2022
                 Algorithm.HMAC256("fakeSecret"),
-                Clock.fixed(Instant.ofEpochSecond(1648760741), ZoneId.of("Europe/Warsaw")), //fixed 31.03.2022
                 60000
         );
     }
 
     @Test
-    void givenValidJwt_tryRetrieveNick_nickIsPresent() {
+    void givenValidJwt_verifyToken_userIsPresent() {
         String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-                "eyJzdWIiOiJ1c2VyMSIsImV4cCI6MjE0NzQ4MzY0N30." +
-                "L-OzhC0g5TVQr0tcg75S1pGn57vr1MjumtHT_atU3Ag";
+                "eyJzdWIiOiJ1c2VyMSIsImV4cCI6MjE0NzQ4MzY0NywidXNlcklkIjoxfQ." +
+                "0VtPh11XONzdozSYi5Xp1AA8vMSzhfbEuLXen_dR_II";
 
-        var nick = jwtService.tryRetrieveNick(jwt);
+        var user = jwtService.verifyToken(jwt);
 
-        assertThat(nick).isPresent();
-        assertThat(nick.get()).isEqualTo("user1");
+        assertThat(user).isPresent();
+        assertThat(user.get().getId()).isEqualTo(1);
+        assertThat(user.get().getNick()).isEqualTo("user1");
     }
 
     @Test
-    void givenInvalidJwt_tryRetrieveNick_nickIsEmpty() {
+    void givenInvalidJwt_verifyToken_userIsEmpty() {
         String jwt = "sadasfgasfasfafasf." +
                 "fasfasfsaafsfsafasfas." +
                 "asfldsaklmadsklmdsklaafs";
 
-        var nick = jwtService.tryRetrieveNick(jwt);
+        var user = jwtService.verifyToken(jwt);
 
-        assertThat(nick).isEmpty();
+        assertThat(user).isEmpty();
     }
 
     @Test
-    void givenExpiredJwt_tryRetrieveNick_nickIsEmpty() {
+    void givenExpiredJwt_verifyToken_userIsEmpty() {
         String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-                "eyJzdWIiOiJ1c2VyMSIsImV4cCI6MX0." +
-                "UHL3UhDJ49UfA1edalNCbtiRScdhU8psgzMrSs7gR-4";
+                "eyJzdWIiOiJ1c2VyMSIsInVzZXJJZCI6MSwiZXhwIjoxNjQ4NzYwNzQwfQ." +
+                "IhOVEyDGHSqrt7mcpdvsW-7KC-QNgcbkhR4figQ2IZU";
 
-        var nick = jwtService.tryRetrieveNick(jwt);
+        var user = jwtService.verifyToken(jwt);
 
-        assertThat(nick).isEmpty();
+        assertThat(user).isEmpty();
     }
 
     @Test
     void givenNick_createAccessToken_returnsToken() {
         String expectedJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." +
-                "eyJzdWIiOiJ1c2VyMSIsImV4cCI6MTY0ODc2MDgwMX0." +
-                "rf5LmtR4iMmkjWbWZqbqG8uKrlnDuWgaRsIxaSiyEAw";
+                "eyJzdWIiOiJ1c2VyMSIsImV4cCI6MTY0ODc2MDgwMSwidXNlcklkIjoxfQ." +
+                "frgIQ_4mnd5SiGYYZdmkWosVxqIN5gRJEGh6diDuNnY";
 
-        String token = jwtService.createAccessToken("user1");
+        var user = new User("user1", "", "");
+        user.setId(1);
+
+        String token = jwtService.createAccessToken(user);
 
         assertThat(token).isEqualTo(expectedJwt);
     }


### PR DESCRIPTION
- Store User object with ID and nick in security context, instead of
storing just nick.
- User object can be obtained by using 'Current' annotation on argument
of controller method.
- Inject auth0 clock to JwtService. Previously, clock was not injected
to JWTVerifier, which could have resulted in failure of tests depending
on the OS time.